### PR TITLE
[1-Typos] Fix typos.

### DIFF
--- a/lab1/readme.md
+++ b/lab1/readme.md
@@ -3,7 +3,7 @@
 Before we get started, please run
 
 ```
-cd lab2_soln/
+cd lab2_sln/
 pipenv run python text_recognizer/datasets/emnist_dataset.py
 cd ..
 ```
@@ -15,7 +15,7 @@ Familiarize you with the high-level organizational design of the codebase
 ## Follow along
 
 ```
-cd lab9_soln/
+cd lab9_sln/
 ```
 
 ## Project structure

--- a/lab1_sln/readme.md
+++ b/lab1_sln/readme.md
@@ -3,7 +3,7 @@
 Before we get started, please run
 
 ```
-cd lab2_soln/
+cd lab2_sln/
 pipenv run python text_recognizer/datasets/emnist_dataset.py
 cd ..
 ```
@@ -15,7 +15,7 @@ Familiarize you with the high-level organizational design of the codebase
 ## Follow along
 
 ```
-cd lab9_soln/
+cd lab9_sln/
 ```
 
 ## Project structure

--- a/lab3/readme.md
+++ b/lab3/readme.md
@@ -13,7 +13,7 @@ Move from reading single characters to reading entire lines.
 ## Follow along
 
 ```
-cd lab3_soln/
+cd lab3_sln/
 ```
 
 ## Intro to the EMNIST Lines dataset

--- a/lab3_sln/readme.md
+++ b/lab3_sln/readme.md
@@ -13,7 +13,7 @@ Move from reading single characters to reading entire lines.
 ## Follow along
 
 ```
-cd lab3_soln/
+cd lab3_sln/
 ```
 
 ## Intro to the EMNIST Lines dataset

--- a/lab4/readme.md
+++ b/lab4/readme.md
@@ -13,7 +13,7 @@ Get familiar with our experiment running and experiment management tools
 
 ```
 git pull
-cd lab4_soln/
+cd lab4_sln/
 ```
 
 ## Intro to Weights & Biases

--- a/lab4_sln/readme.md
+++ b/lab4_sln/readme.md
@@ -13,7 +13,7 @@ Get familiar with our experiment running and experiment management tools
 
 ```
 git pull
-cd lab4_soln/
+cd lab4_sln/
 ```
 
 ## Intro to Weights & Biases

--- a/lab5/readme.md
+++ b/lab5/readme.md
@@ -15,7 +15,7 @@ In this lab we will introduce the IAM handwriting dataset, and give you a chance
 ## Follow along
 
 ```
-cd lab5_soln/
+cd lab5_sln/
 wandb init
    - team: fsdl
    - project: fsdl-text-recognizer-project

--- a/lab5_sln/readme.md
+++ b/lab5_sln/readme.md
@@ -15,7 +15,7 @@ In this lab we will introduce the IAM handwriting dataset, and give you a chance
 ## Follow along
 
 ```
-cd lab5_soln/
+cd lab5_sln/
 wandb init
    - team: fsdl
    - project: fsdl-text-recognizer-project


### PR DESCRIPTION
Hi!

In this PR I am just fixing some typos, where in some **readme.md** files, the paths for the solutions were **lab[lab number]_soln** instead of **lab[lab number]_sln**.

Thanks,