### PR TITLE
Fix module search path

### DIFF
--- a/lab1/readme.md
+++ b/lab1/readme.md
@@ -4,7 +4,7 @@ Before we get started, please run
 
 ```
 cd lab2_sln/
-pipenv run python text_recognizer/datasets/emnist_dataset.py
+pipenv run python3 -m text_recognizer.datasets.emnist_dataset
 cd ..
 ```
 

--- a/lab1_sln/readme.md
+++ b/lab1_sln/readme.md
@@ -4,7 +4,7 @@ Before we get started, please run
 
 ```
 cd lab2_sln/
-pipenv run python text_recognizer/datasets/emnist_dataset.py
+pipenv run python3 -m text_recognizer.datasets.emnist_dataset
 cd ..
 ```
 

--- a/lab2/text_recognizer/datasets/__init__.py
+++ b/lab2/text_recognizer/datasets/__init__.py
@@ -1,1 +1,1 @@
-from .emnist_dataset import EmnistDataset
+#from .emnist_dataset import EmnistDataset

--- a/lab2_sln/text_recognizer/datasets/__init__.py
+++ b/lab2_sln/text_recognizer/datasets/__init__.py
@@ -1,1 +1,1 @@
-from .emnist_dataset import EmnistDataset
+#from .emnist_dataset import EmnistDataset


### PR DESCRIPTION
👋 I found that when trying to run the given instructions, I was getting errors about not being able to find the `text_recognizer` module. Changing the instructions to invoke the `emnist_dataset` as part of a package triggers the right module search path and seems to do the trick (see updated readme below). 

However, that then led to a runtime warning:
```
/usr/lib/python3.6/runpy.py:125: RuntimeWarning: 'text_recognizer.datasets.emnist_dataset' found in sys.modules aft
er import of package 'text_recognizer.datasets', but prior to execution of 'text_recognizer.datasets.emnist_dataset
'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
```

Commenting out the explicit call to `.emnist_dataset` in `datasets/__init__.py` seems to solve that. There's probably a reason that was in there in the first place though 👀 😬 